### PR TITLE
ANDROID-11430 glEsVersion checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ To add the PermissionCheck plugin to your project, you have to add this block of
 
 ```groovy
 plugins {
-    id "com.telefonica.manifestcheck" version "1.0.0"
+    id "com.telefonica.manifestcheck" version "1.0.1"
 }
 ```
 
@@ -57,7 +57,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath "com.telefonica:manifestcheck:1.0.0"
+        classpath "com.telefonica:manifestcheck:1.0.1"
     }
 }
 ```

--- a/manifestcheck/build.gradle.kts
+++ b/manifestcheck/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "com.telefonica"
-version = "1.0.0" // Also update the version in the README
+version = "1.0.1" // Also update the version in the README
 
 val uber: Configuration by configurations.creating
 

--- a/manifestcheck/src/test/kotlin/io/github/simonschiller/permissioncheck/MultiVariantPermissionCheckIntegrationTest.kt
+++ b/manifestcheck/src/test/kotlin/io/github/simonschiller/permissioncheck/MultiVariantPermissionCheckIntegrationTest.kt
@@ -36,12 +36,14 @@ class MultiVariantPermissionCheckIntegrationTest {
                     <uses-permission maxSdkVersion="26" name="android.permission.CAMERA"/>
                     <uses-permission-sdk-23 name="android.permission.ACCESS_NETWORK_STATE"/>
                     <uses-feature name="android.hardware.camera.autofocus" required="false"/>
+                    <uses-feature glEsVersion="0x00020000" required="true"/>
                 </variant>
                 <variant name="release">
                     <uses-permission name="android.permission.INTERNET"/>
                     <uses-permission maxSdkVersion="26" name="android.permission.CAMERA"/>
                     <uses-permission-sdk-23 name="android.permission.ACCESS_NETWORK_STATE"/>
                     <uses-feature name="android.hardware.camera.autofocus" required="false"/>
+                    <uses-feature glEsVersion="0x00020000" required="true"/>
                 </variant>
             </baseline>
 
@@ -80,12 +82,14 @@ class MultiVariantPermissionCheckIntegrationTest {
                     <uses-permission maxSdkVersion="26" name="android.permission.CAMERA"/>
                     <uses-permission-sdk-23 name="android.permission.ACCESS_NETWORK_STATE"/>
                     <uses-feature name="android.hardware.camera.autofocus" required="false"/>
+                    <uses-feature glEsVersion="0x00020000" required="true"/>
                 </variant>
                 <variant name="debug">
                     <uses-permission name="android.permission.INTERNET"/>
                     <uses-permission maxSdkVersion="26" name="android.permission.CAMERA"/>
                     <uses-permission-sdk-23 name="android.permission.ACCESS_NETWORK_STATE"/>
                     <uses-feature name="android.hardware.camera.autofocus" required="false"/>
+                    <uses-feature glEsVersion="0x00020000" required="true"/>
                 </variant>
             </baseline>
             
@@ -112,12 +116,14 @@ class MultiVariantPermissionCheckIntegrationTest {
                     <uses-permission maxSdkVersion="26" name="android.permission.CAMERA"/>
                     <uses-permission-sdk-23 name="android.permission.ACCESS_NETWORK_STATE"/>
                     <uses-feature name="android.hardware.camera.autofocus" required="false"/>
+                    <uses-feature glEsVersion="0x00020000" required="true"/>
                 </variant>
                 <variant name="release">
                     <uses-permission name="android.permission.INTERNET"/>
                     <uses-permission maxSdkVersion="26" name="android.permission.CAMERA"/>
                     <uses-permission-sdk-23 name="android.permission.ACCESS_NETWORK_STATE"/>
                     <uses-feature name="android.hardware.camera.autofocus" required="false"/>
+                    <uses-feature glEsVersion="0x00020000" required="true"/>
                 </variant>
             </baseline>
             

--- a/manifestcheck/src/test/kotlin/io/github/simonschiller/permissioncheck/SingleVariantPermissionCheckIntegrationTest.kt
+++ b/manifestcheck/src/test/kotlin/io/github/simonschiller/permissioncheck/SingleVariantPermissionCheckIntegrationTest.kt
@@ -36,9 +36,10 @@ class SingleVariantPermissionCheckIntegrationTest {
                     <uses-permission maxSdkVersion="26" name="android.permission.CAMERA"/>
                     <uses-permission-sdk-23 name="android.permission.ACCESS_NETWORK_STATE"/>
                     <uses-feature name="android.hardware.camera.autofocus" required="false"/>
+                    <uses-feature glEsVersion="0x00020000" required="true"/>
                 </variant>
             </baseline>
-            
+
         """.trimIndent()
         assertEquals(baseline, androidProject.baselineFile.readText().normaliseLineSeparators())
     }
@@ -79,6 +80,7 @@ class SingleVariantPermissionCheckIntegrationTest {
                     <uses-permission maxSdkVersion="26" name="android.permission.CAMERA"/>
                     <uses-permission-sdk-23 name="android.permission.ACCESS_NETWORK_STATE"/>
                     <uses-feature name="android.hardware.camera.autofocus" required="false"/>
+                    <uses-feature glEsVersion="0x00020000" required="true"/>
                 </variant>
             </baseline>
             
@@ -105,6 +107,7 @@ class SingleVariantPermissionCheckIntegrationTest {
                     <uses-permission maxSdkVersion="26" name="android.permission.CAMERA"/>
                     <uses-permission-sdk-23 name="android.permission.ACCESS_NETWORK_STATE"/>
                     <uses-feature name="android.hardware.camera.autofocus" required="false"/>
+                    <uses-feature glEsVersion="0x00020000" required="true"/>
                 </variant>
             </baseline>
             

--- a/manifestcheck/src/test/kotlin/io/github/simonschiller/permissioncheck/testutil/AndroidProjectExtension.kt
+++ b/manifestcheck/src/test/kotlin/io/github/simonschiller/permissioncheck/testutil/AndroidProjectExtension.kt
@@ -42,12 +42,14 @@ class AndroidProjectExtension : BeforeEachCallback, AfterEachCallback {
             <baseline>
                 <variant name="debug">
                     <uses-feature name="android.hardware.camera.autofocus" required="false"/>
+                    <uses-feature glEsVersion="0x00020000" required="true"/>
                     <uses-permission name="android.permission.INTERNET"/>
                     <uses-permission maxSdkVersion="26" name="android.permission.CAMERA"/>
                     <uses-permission-sdk-23 name="android.permission.ACCESS_NETWORK_STATE"/>
                 </variant>
                 <variant name="release">
                     <uses-feature name="android.hardware.camera.autofocus" required="false"/>
+                    <uses-feature glEsVersion="0x00020000" required="true"/>
                     <uses-permission name="android.permission.INTERNET"/>
                     <uses-permission maxSdkVersion="26" name="android.permission.CAMERA"/>
                     <uses-permission-sdk-23 name="android.permission.ACCESS_NETWORK_STATE"/>
@@ -62,12 +64,14 @@ class AndroidProjectExtension : BeforeEachCallback, AfterEachCallback {
             <baseline>
                 <variant name="debug">
                     <uses-feature name="android.hardware.camera.autofocus" required="true"/>
+                    <uses-feature glEsVersion="0x00020000" required="true"/>
                     <uses-permission maxSdkVersion="24" name="android.permission.CAMERA"/>
                     <uses-permission-sdk-23 name="android.permission.ACCESS_NETWORK_STATE"/>
                     <uses-permission name="android.permission.ACCESS_COARSE_LOCATION"/>
                 </variant>
                 <variant name="release">
                     <uses-feature name="android.hardware.camera.autofocus" required="true"/>
+                    <uses-feature glEsVersion="0x00020000" required="true"/>
                     <uses-permission maxSdkVersion="24" name="android.permission.CAMERA"/>
                     <uses-permission-sdk-23 name="android.permission.ACCESS_NETWORK_STATE"/>
                     <uses-permission name="android.permission.ACCESS_COARSE_LOCATION"/>
@@ -159,6 +163,7 @@ class AndroidProjectExtension : BeforeEachCallback, AfterEachCallback {
                 package="io.github.simonschiller.permissioncheck.sample.app">
 
                 <uses-feature android:name="android.hardware.camera.autofocus" android:required="false" />
+                <uses-feature android:glEsVersion="0x00020000" android:required="true" />
                 <uses-permission android:name="android.permission.INTERNET" />
                 <uses-permission android:name="android.permission.CAMERA" android:maxSdkVersion="26" />
                 <uses-permission-sdk-23 android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/plugin-core/src/main/kotlin/io/github/simonschiller/permissioncheck/internal/BaselineHandler.kt
+++ b/plugin-core/src/main/kotlin/io/github/simonschiller/permissioncheck/internal/BaselineHandler.kt
@@ -83,7 +83,8 @@ internal class BaselineHandler(private val baselineFile: File) {
             features.forEach { element ->
                 val name = element.getAttribute("name")
                 val required = element.getAttribute("required").toBooleanStrictOrNull()
-                variantPermissions += Feature(name, required)
+                val glEsVersion = element.getAttribute("glEsVersion").takeIf { it.isNotEmpty() }
+                variantPermissions += Feature(name, required, glEsVersion)
             }
 
             permissions[variantName] = variantPermissions

--- a/plugin-core/src/main/kotlin/io/github/simonschiller/permissioncheck/internal/ManifestParser.kt
+++ b/plugin-core/src/main/kotlin/io/github/simonschiller/permissioncheck/internal/ManifestParser.kt
@@ -28,7 +28,7 @@ internal class ManifestParser {
 
         // Parse features
         permissions += parseNodes(document, "uses-feature").map { node ->
-            Feature(node.name, node.required)
+            Feature(node.name, node.required, node.glEsVersion)
         }
 
         return permissions
@@ -44,10 +44,11 @@ internal class ManifestParser {
             val name = element.getAttributeNS(namespace, "name")
             val maxSdkVersion = element.getAttributeNS(namespace, "maxSdkVersion").toIntOrNull()
             val required = element.getAttributeNS(namespace, "required").toBooleanStrictOrNull()
-            nodes += Node(name, maxSdkVersion, required)
+            val glEsVersion = element.getAttributeNS(namespace, "glEsVersion").takeIf { it.isNotEmpty() }
+            nodes += Node(name, maxSdkVersion, required, glEsVersion)
         }
         return nodes.toSet()
     }
 
-    data class Node(val name: String, val maxSdkVersion: Int?, val required: Boolean?)
+    data class Node(val name: String, val maxSdkVersion: Int?, val required: Boolean?, val glEsVersion: String?)
 }

--- a/plugin-core/src/main/kotlin/io/github/simonschiller/permissioncheck/internal/PermissionChecker.kt
+++ b/plugin-core/src/main/kotlin/io/github/simonschiller/permissioncheck/internal/PermissionChecker.kt
@@ -55,6 +55,8 @@ internal class PermissionChecker {
             else -> {
                 if (manifest.required != baseline.required) {
                     Violation.RequiredChanged(manifest, baseline.required)
+                } else if (manifest.glEsVersion != baseline.glEsVersion) {
+                    Violation.GlEsVersionChanged(manifest, baseline.glEsVersion)
                 } else {
                     error("Could not determine violation for permissions $manifest and $baseline")
                 }

--- a/plugin-core/src/main/kotlin/io/github/simonschiller/permissioncheck/internal/data/Permissions.kt
+++ b/plugin-core/src/main/kotlin/io/github/simonschiller/permissioncheck/internal/data/Permissions.kt
@@ -4,28 +4,39 @@ import org.w3c.dom.Document
 import org.w3c.dom.Element
 import java.util.*
 
-internal abstract class BasePermission(val name: String, val maxSdkVersion: Int?, val required: Boolean?) : Comparable<BasePermission> {
+internal abstract class BasePermission(val name: String, val maxSdkVersion: Int?, val required: Boolean?, val glEsVersion: String?) : Comparable<BasePermission> {
     abstract val tag: String
 
     fun toXmlElement(document: Document): Element = document.createElement(tag).apply {
-        setAttribute("name", name)
+        if (name.isNotEmpty()) {
+            setAttribute("name", name)
+        }
         if (maxSdkVersion != null) {
             setAttribute("maxSdkVersion", maxSdkVersion.toString())
         }
         if (required != null) {
             setAttribute("required", required.toString())
         }
+        if (glEsVersion != null) {
+            setAttribute("glEsVersion", glEsVersion)
+        }
     }
 
-    abstract fun copy(name: String = this.name, maxSdkVersion: Int? = this.maxSdkVersion, required: Boolean?): BasePermission
+    abstract fun copy(name: String = this.name, maxSdkVersion: Int? = this.maxSdkVersion, required: Boolean?, glEsVersion: String?): BasePermission
 
     override fun toString(): String {
-        val builder = StringBuilder("""<$tag android:name="$name" """)
+        val builder = StringBuilder("""<$tag """)
+        if (name.isNotEmpty()) {
+            builder.append("""android:name="$name" """)
+        }
         if (maxSdkVersion != null) {
             builder.append("""android:maxSdkVersion="$maxSdkVersion" """)
         }
         if (required != null) {
             builder.append("""android:required="$required" """)
+        }
+        if (required != null) {
+            builder.append("""android:glEsVersion="$glEsVersion" """)
         }
         return builder.append("/>").toString()
     }
@@ -33,7 +44,7 @@ internal abstract class BasePermission(val name: String, val maxSdkVersion: Int?
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is BasePermission) return false
-        return name == other.name && maxSdkVersion == other.maxSdkVersion && required == other.required && tag == other.tag
+        return name == other.name && maxSdkVersion == other.maxSdkVersion && required == other.required && glEsVersion == other.glEsVersion && tag == other.tag
     }
 
     override fun hashCode(): Int {
@@ -49,17 +60,17 @@ internal abstract class BasePermission(val name: String, val maxSdkVersion: Int?
     }
 }
 
-internal class Permission(name: String, maxSdkVersion: Int? = null) : BasePermission(name, maxSdkVersion, null) {
+internal class Permission(name: String, maxSdkVersion: Int? = null) : BasePermission(name, maxSdkVersion, null, null) {
     override val tag: String = "uses-permission"
-    override fun copy(name: String, maxSdkVersion: Int?, required: Boolean?) = Permission(name, maxSdkVersion)
+    override fun copy(name: String, maxSdkVersion: Int?, required: Boolean?, glEsVersion: String?) = Permission(name, maxSdkVersion)
 }
 
-internal class Sdk23Permission(name: String, maxSdkVersion: Int? = null) : BasePermission(name, maxSdkVersion, null) {
+internal class Sdk23Permission(name: String, maxSdkVersion: Int? = null) : BasePermission(name, maxSdkVersion, null, null) {
     override val tag: String = "uses-permission-sdk-23"
-    override fun copy(name: String, maxSdkVersion: Int?, required: Boolean?) = Sdk23Permission(name, maxSdkVersion)
+    override fun copy(name: String, maxSdkVersion: Int?, required: Boolean?, glEsVersion: String?) = Sdk23Permission(name, maxSdkVersion)
 }
 
-internal class Feature(name: String, required: Boolean? = null) : BasePermission(name, null, required) {
+internal class Feature(name: String, required: Boolean? = null, glEsVersion: String? = null) : BasePermission(name, null, required, glEsVersion) {
     override val tag: String = "uses-feature"
-    override fun copy(name: String, maxSdkVersion: Int?, required: Boolean?) = Feature(name, required)
+    override fun copy(name: String, maxSdkVersion: Int?, required: Boolean?, glEsVersion: String?) = Feature(name, required, glEsVersion)
 }

--- a/plugin-core/src/main/kotlin/io/github/simonschiller/permissioncheck/internal/data/Permissions.kt
+++ b/plugin-core/src/main/kotlin/io/github/simonschiller/permissioncheck/internal/data/Permissions.kt
@@ -35,7 +35,7 @@ internal abstract class BasePermission(val name: String, val maxSdkVersion: Int?
         if (required != null) {
             builder.append("""android:required="$required" """)
         }
-        if (required != null) {
+        if (glEsVersion != null) {
             builder.append("""android:glEsVersion="$glEsVersion" """)
         }
         return builder.append("/>").toString()

--- a/plugin-core/src/main/kotlin/io/github/simonschiller/permissioncheck/internal/data/Violation.kt
+++ b/plugin-core/src/main/kotlin/io/github/simonschiller/permissioncheck/internal/data/Violation.kt
@@ -81,4 +81,17 @@ internal sealed class Violation {
             setAttribute("previousRequired", required?.toString() ?: "-")
         }
     }
+
+    data class GlEsVersionChanged(override val permission: BasePermission, val glEsVersion: String?) : Violation() {
+        override val message = "GlEsVersion of '$permission' has changed (glEsVersion ${glEsVersion ?: "-"})"
+
+        override val type = "glEsVersion-changed"
+
+        override val title = "glEsVersion changed"
+        override val description = "glEsVersion has changed."
+
+        override fun toXmlElement(document: Document) = super.toXmlElement(document).apply {
+            setAttribute("previousRequired", glEsVersion?.toString() ?: "-")
+        }
+    }
 }

--- a/plugin-core/src/main/kotlin/io/github/simonschiller/permissioncheck/internal/report/HtmlReporter.kt
+++ b/plugin-core/src/main/kotlin/io/github/simonschiller/permissioncheck/internal/report/HtmlReporter.kt
@@ -100,9 +100,10 @@ internal class HtmlReporter(private val reportFile: File) : Reporter {
         val oldPermission = when (violation) {
             is Violation.Added -> null
             is Violation.Removed -> violation.permission
-            is Violation.MaxSdkIncreased -> violation.permission.copy(maxSdkVersion = violation.from, required = false)
-            is Violation.MaxSdkDecreased -> violation.permission.copy(maxSdkVersion = violation.from, required = false)
-            is Violation.RequiredChanged -> violation.permission.copy(maxSdkVersion = null, required = violation.required)
+            is Violation.MaxSdkIncreased -> violation.permission.copy(maxSdkVersion = violation.from, required = false, glEsVersion = null)
+            is Violation.MaxSdkDecreased -> violation.permission.copy(maxSdkVersion = violation.from, required = false, glEsVersion = null)
+            is Violation.RequiredChanged -> violation.permission.copy(maxSdkVersion = null, required = violation.required, glEsVersion = null)
+            is Violation.GlEsVersionChanged -> violation.permission.copy(maxSdkVersion = null, required = null, glEsVersion = violation.glEsVersion)
         }
 
         // Removed code snippet
@@ -116,6 +117,7 @@ internal class HtmlReporter(private val reportFile: File) : Reporter {
             is Violation.MaxSdkIncreased -> violation.permission
             is Violation.MaxSdkDecreased -> violation.permission
             is Violation.RequiredChanged -> violation.permission
+            is Violation.GlEsVersionChanged -> violation.permission
         }
 
         // Added code snippet

--- a/plugin-core/src/test/kotlin/io/github/simonschiller/permissioncheck/internal/data/PermissionsTest.kt
+++ b/plugin-core/src/test/kotlin/io/github/simonschiller/permissioncheck/internal/data/PermissionsTest.kt
@@ -68,12 +68,12 @@ class PermissionsTest {
     @Test
     fun `Copying permissions works`() {
         val original = Permission("android.permission.CAMERA", 26)
-        val exactCopy = original.copy(required = false)
+        val exactCopy = original.copy(required = false, glEsVersion = null)
 
         assertEquals(original, exactCopy)
         assertNotSame(original, exactCopy)
 
-        val changedCopy = original.copy(maxSdkVersion = null, required = false)
+        val changedCopy = original.copy(maxSdkVersion = null, required = false, glEsVersion = null)
         assertEquals("android.permission.CAMERA", changedCopy.name)
         assertNull(changedCopy.maxSdkVersion)
     }

--- a/sample/app/sample-baseline.xml
+++ b/sample/app/sample-baseline.xml
@@ -8,6 +8,7 @@
         <uses-permission maxSdkVersion="26" name="android.permission.ACCESS_FINE_LOCATION"/>
         <uses-permission-sdk-23 name="android.permission.ACCESS_NETWORK_STATE"/>
         <uses-feature name="android.hardware.camera.autofocus" required="false"/>
+        <uses-feature glEsVersion="0x00020000" required="true"/>
     </variant>
     <variant name="release">
         <uses-permission name="android.permission.CAMERA"/>
@@ -17,5 +18,6 @@
         <uses-permission maxSdkVersion="26" name="android.permission.ACCESS_FINE_LOCATION"/>
         <uses-permission-sdk-23 name="android.permission.ACCESS_NETWORK_STATE"/>
         <uses-feature name="android.hardware.camera.autofocus" required="false"/>
+        <uses-feature glEsVersion="0x00020000" required="true"/>
     </variant>
 </baseline>

--- a/sample/app/src/main/AndroidManifest.xml
+++ b/sample/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
     package="io.github.simonschiller.permissioncheck.sample.app">
 
     <uses-feature android:name="android.hardware.camera.autofocus" android:required="false" />
+    <uses-feature android:glEsVersion="0x00020000" android:required="true" />
     <uses-permission android:name="android.permission.INTERNET" android:maxSdkVersion="27"  />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" android:maxSdkVersion="26" />


### PR DESCRIPTION
### :tickets: Jira ticket
[ANDROID-11430](https://jira.tid.es/browse/ANDROID-11430)

### :goal_net: What's the goal?
Using glEsVersion attribute as well for the permissions as detected in https://github.com/Telefonica/android-messenger/pull/1477 that is necessary.

### :construction: How do we do it?
- Adding glEsVersion to the checks and also to the tests.
- Updating the lib version to 1.0.1

### To run the plugin locally with the sample app:
- Uncomment the lines in settings.gradle.kts and the build.gradle.kts of the project.
> ./gradlew jar
> ./gradlew publishToMavenLocal
> ./gradlew checkPermissions

### To run the tests:
> ./gradlew test 
