### PR TITLE
ANDROID-15083 add variant ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ To add the PermissionCheck plugin to your project, you have to add this block of
 
 ```groovy
 plugins {
-    id "com.telefonica.manifestcheck" version "1.0.1"
+    id "com.telefonica.manifestcheck" version "1.0.2"
 }
 ```
 
@@ -57,7 +57,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath "com.telefonica:manifestcheck:1.0.1"
+        classpath "com.telefonica:manifestcheck:1.0.2"
     }
 }
 ```

--- a/manifestcheck/build.gradle.kts
+++ b/manifestcheck/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "com.telefonica"
-version = "1.0.1" // Also update the version in the README
+version = "1.0.2" // Also update the version in the README
 
 val uber: Configuration by configurations.creating
 

--- a/manifestcheck/src/test/kotlin/io/github/simonschiller/permissioncheck/MultiVariantPermissionCheckIntegrationTest.kt
+++ b/manifestcheck/src/test/kotlin/io/github/simonschiller/permissioncheck/MultiVariantPermissionCheckIntegrationTest.kt
@@ -77,14 +77,14 @@ class MultiVariantPermissionCheckIntegrationTest {
         val baseline = """
             <?xml version="1.0" encoding="UTF-8" standalone="no"?>
             <baseline>
-                <variant name="release">
+                <variant name="debug">
                     <uses-permission name="android.permission.INTERNET"/>
                     <uses-permission maxSdkVersion="26" name="android.permission.CAMERA"/>
                     <uses-permission-sdk-23 name="android.permission.ACCESS_NETWORK_STATE"/>
                     <uses-feature name="android.hardware.camera.autofocus" required="false"/>
                     <uses-feature glEsVersion="0x00020000" required="true"/>
                 </variant>
-                <variant name="debug">
+                <variant name="release">
                     <uses-permission name="android.permission.INTERNET"/>
                     <uses-permission maxSdkVersion="26" name="android.permission.CAMERA"/>
                     <uses-permission-sdk-23 name="android.permission.ACCESS_NETWORK_STATE"/>

--- a/manifestcheck/src/test/kotlin/io/github/simonschiller/permissioncheck/SingleVariantPermissionCheckIntegrationTest.kt
+++ b/manifestcheck/src/test/kotlin/io/github/simonschiller/permissioncheck/SingleVariantPermissionCheckIntegrationTest.kt
@@ -70,17 +70,17 @@ class SingleVariantPermissionCheckIntegrationTest {
         val baseline = """
             <?xml version="1.0" encoding="UTF-8" standalone="no"?>
             <baseline>
-                <variant name="release">
-                    <uses-permission name="android.permission.INTERNET"/>
-                    <uses-permission maxSdkVersion="26" name="android.permission.CAMERA"/>
-                    <uses-permission-sdk-23 name="android.permission.ACCESS_NETWORK_STATE"/>
-                </variant>
                 <variant name="debug">
                     <uses-permission name="android.permission.INTERNET"/>
                     <uses-permission maxSdkVersion="26" name="android.permission.CAMERA"/>
                     <uses-permission-sdk-23 name="android.permission.ACCESS_NETWORK_STATE"/>
                     <uses-feature name="android.hardware.camera.autofocus" required="false"/>
                     <uses-feature glEsVersion="0x00020000" required="true"/>
+                </variant>
+                <variant name="release">
+                    <uses-permission name="android.permission.INTERNET"/>
+                    <uses-permission maxSdkVersion="26" name="android.permission.CAMERA"/>
+                    <uses-permission-sdk-23 name="android.permission.ACCESS_NETWORK_STATE"/>
                 </variant>
             </baseline>
             

--- a/plugin-core/src/main/kotlin/io/github/simonschiller/permissioncheck/PermissionCheckTask.kt
+++ b/plugin-core/src/main/kotlin/io/github/simonschiller/permissioncheck/PermissionCheckTask.kt
@@ -70,7 +70,7 @@ open class PermissionCheckTask : DefaultTask() {
 
         // Create (or recreate) the baseline if needed
         if (recreate.get() || !baselineFile.exists()) {
-            baselineHandler.serialize(permissions)
+            baselineHandler.serialize(permissions, recreate.get())
             project.logger.lifecycle("Created baseline at $baselineFile")
             if (!recreate.get()) { // New baseline created without explicit flag -> fail the build
                 abortBuild()

--- a/plugin-core/src/main/kotlin/io/github/simonschiller/permissioncheck/config/TaskConfigurator.kt
+++ b/plugin-core/src/main/kotlin/io/github/simonschiller/permissioncheck/config/TaskConfigurator.kt
@@ -43,7 +43,7 @@ abstract class TaskConfigurator {
         extension: PermissionCheckExtension,
         variantName: String
     ): TaskProvider<PermissionCheckTask> {
-        val taskName = "check${variantName.capitalize(Locale.ROOT)}Permissions"
+        val taskName = "check${variantName.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.ROOT) else it.toString() }}Permissions"
 
         return project.tasks.register(taskName, PermissionCheckTask::class.java) { task ->
             task.group = LifecycleBasePlugin.VERIFICATION_GROUP

--- a/plugin-core/src/main/kotlin/io/github/simonschiller/permissioncheck/internal/BaselineHandler.kt
+++ b/plugin-core/src/main/kotlin/io/github/simonschiller/permissioncheck/internal/BaselineHandler.kt
@@ -19,16 +19,16 @@ internal class BaselineHandler(private val baselineFile: File) {
         }
     }
 
-    fun serialize(permissions: Map<String, Set<BasePermission>>) {
-        val baseline = deserialize().toMutableMap() // Parse existing baseline and add new or updated permissions
-        permissions.forEach { (variantName, variantPermissions) ->
+    fun serialize(permissions: Map<String, Set<BasePermission>>, recreate: Boolean = false) {
+        val baseline = if (!recreate) deserialize().toMutableMap() else mutableMapOf() // Parse existing baseline and add new or updated permissions
+        permissions.toSortedMap().forEach { (variantName, variantPermissions) ->
             baseline[variantName] = variantPermissions
         }
 
         // Package changes into a XML document
         val document = createDocumentBuilder().newDocument()
         document.appendElement("baseline") {
-            baseline.forEach { (variantName, variantPermissions) ->
+            baseline.toSortedMap().forEach { (variantName, variantPermissions) ->
 
                 // Create permission entries for a single variant
                 appendElement("variant") {


### PR DESCRIPTION
### :tickets: Jira ticket
[ANDROID-15083](https://jira.tid.es/browse/ANDROID-15083)

### :goal_net: What's the goal?
The plugin should generate a baseline output with a consistent and predictable sorting of entries.

It currently does so but once the baseline exists if any of the variant is not in the order it would be when the baseline is created it will not reorder it. 
Also if a new variant is added to the baseline it will add it to the end instead of following the order it should be if the baseline was created from scratch.

This task is to fix those 2 issues.

### :construction: How do we do it?
Adding tests to solve those couple of ordering issues and make them pass.
Update existing tests affected also by this change.

### To execute this:
> ./gradlew test 

