### PR TITLE
Restore plugin tags ANDROID-17380

### DIFF
--- a/manifestcheck/build.gradle.kts
+++ b/manifestcheck/build.gradle.kts
@@ -46,6 +46,7 @@ gradlePlugin {
             displayName = "ManifestCheck"
             description = "ManifestCheck is a Gradle plugin that helps you catch Android permission/feature regressions automatically."
             implementationClass = "com.telefonica.manifestcheck.PermissionCheckPlugin"
+            tags = listOf("manifestcheck", "permissions")
         }
     }
     website = "https://github.com/Telefonica/android-permissioncheck"


### PR DESCRIPTION
The plugin was not published without this https://github.com/Telefonica/android-permissioncheck/actions/runs/21900477356/job/63227129983

> Caused by: java.lang.IllegalArgumentException: Plugin 'manifestcheck' has no 'tags' property set

And it works with this tags: https://github.com/Telefonica/android-permissioncheck/actions/runs/21901349251/job/63230154300

The tags were removed by mistake in https://github.com/Telefonica/android-permissioncheck/pull/10/changes#:~:text=%2D-,tags,-%3D%20listOf(