### PR TITLE
Sort permissions ANDROID-17565

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ To add the PermissionCheck plugin to your project, you have to add this block of
 
 ```groovy
 plugins {
-    id "com.telefonica.manifestcheck" version "1.1.0"
+    id "com.telefonica.manifestcheck" version "1.1.1"
 }
 ```
 
@@ -57,7 +57,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath "com.telefonica:manifestcheck:1.1.0"
+        classpath "com.telefonica:manifestcheck:1.1.1"
     }
 }
 ```

--- a/manifestcheck/build.gradle.kts
+++ b/manifestcheck/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "com.telefonica"
-version = "1.1.0" // Also update the version in the README
+version = "1.1.1" // Also update the version in the README
 
 val uber: Configuration by configurations.creating
 

--- a/manifestcheck/src/test/kotlin/com/telefonica/manifestcheck/MultiVariantPermissionCheckIntegrationTest.kt
+++ b/manifestcheck/src/test/kotlin/com/telefonica/manifestcheck/MultiVariantPermissionCheckIntegrationTest.kt
@@ -33,18 +33,18 @@ class MultiVariantPermissionCheckIntegrationTest {
             <?xml version="1.0" encoding="UTF-8" standalone="no"?>
             <baseline>
                 <variant name="debug">
-                    <uses-permission name="android.permission.INTERNET"/>
-                    <uses-permission maxSdkVersion="26" name="android.permission.CAMERA"/>
-                    <uses-permission-sdk-23 name="android.permission.ACCESS_NETWORK_STATE"/>
-                    <uses-feature name="android.hardware.camera.autofocus" required="false"/>
                     <uses-feature glEsVersion="0x00020000" required="true"/>
+                    <uses-feature name="android.hardware.camera.autofocus" required="false"/>
+                    <uses-permission-sdk-23 name="android.permission.ACCESS_NETWORK_STATE"/>
+                    <uses-permission maxSdkVersion="26" name="android.permission.CAMERA"/>
+                    <uses-permission name="android.permission.INTERNET"/>
                 </variant>
                 <variant name="release">
-                    <uses-permission name="android.permission.INTERNET"/>
-                    <uses-permission maxSdkVersion="26" name="android.permission.CAMERA"/>
-                    <uses-permission-sdk-23 name="android.permission.ACCESS_NETWORK_STATE"/>
-                    <uses-feature name="android.hardware.camera.autofocus" required="false"/>
                     <uses-feature glEsVersion="0x00020000" required="true"/>
+                    <uses-feature name="android.hardware.camera.autofocus" required="false"/>
+                    <uses-permission-sdk-23 name="android.permission.ACCESS_NETWORK_STATE"/>
+                    <uses-permission maxSdkVersion="26" name="android.permission.CAMERA"/>
+                    <uses-permission name="android.permission.INTERNET"/>
                 </variant>
             </baseline>
 
@@ -79,18 +79,18 @@ class MultiVariantPermissionCheckIntegrationTest {
             <?xml version="1.0" encoding="UTF-8" standalone="no"?>
             <baseline>
                 <variant name="debug">
-                    <uses-permission name="android.permission.INTERNET"/>
-                    <uses-permission maxSdkVersion="26" name="android.permission.CAMERA"/>
-                    <uses-permission-sdk-23 name="android.permission.ACCESS_NETWORK_STATE"/>
-                    <uses-feature name="android.hardware.camera.autofocus" required="false"/>
                     <uses-feature glEsVersion="0x00020000" required="true"/>
+                    <uses-feature name="android.hardware.camera.autofocus" required="false"/>
+                    <uses-permission-sdk-23 name="android.permission.ACCESS_NETWORK_STATE"/>
+                    <uses-permission maxSdkVersion="26" name="android.permission.CAMERA"/>
+                    <uses-permission name="android.permission.INTERNET"/>
                 </variant>
                 <variant name="release">
-                    <uses-permission name="android.permission.INTERNET"/>
-                    <uses-permission maxSdkVersion="26" name="android.permission.CAMERA"/>
-                    <uses-permission-sdk-23 name="android.permission.ACCESS_NETWORK_STATE"/>
-                    <uses-feature name="android.hardware.camera.autofocus" required="false"/>
                     <uses-feature glEsVersion="0x00020000" required="true"/>
+                    <uses-feature name="android.hardware.camera.autofocus" required="false"/>
+                    <uses-permission-sdk-23 name="android.permission.ACCESS_NETWORK_STATE"/>
+                    <uses-permission maxSdkVersion="26" name="android.permission.CAMERA"/>
+                    <uses-permission name="android.permission.INTERNET"/>
                 </variant>
             </baseline>
             
@@ -113,18 +113,18 @@ class MultiVariantPermissionCheckIntegrationTest {
             <?xml version="1.0" encoding="UTF-8" standalone="no"?>
             <baseline>
                 <variant name="debug">
-                    <uses-permission name="android.permission.INTERNET"/>
-                    <uses-permission maxSdkVersion="26" name="android.permission.CAMERA"/>
-                    <uses-permission-sdk-23 name="android.permission.ACCESS_NETWORK_STATE"/>
-                    <uses-feature name="android.hardware.camera.autofocus" required="false"/>
                     <uses-feature glEsVersion="0x00020000" required="true"/>
+                    <uses-feature name="android.hardware.camera.autofocus" required="false"/>
+                    <uses-permission-sdk-23 name="android.permission.ACCESS_NETWORK_STATE"/>
+                    <uses-permission maxSdkVersion="26" name="android.permission.CAMERA"/>
+                    <uses-permission name="android.permission.INTERNET"/>
                 </variant>
                 <variant name="release">
-                    <uses-permission name="android.permission.INTERNET"/>
-                    <uses-permission maxSdkVersion="26" name="android.permission.CAMERA"/>
-                    <uses-permission-sdk-23 name="android.permission.ACCESS_NETWORK_STATE"/>
-                    <uses-feature name="android.hardware.camera.autofocus" required="false"/>
                     <uses-feature glEsVersion="0x00020000" required="true"/>
+                    <uses-feature name="android.hardware.camera.autofocus" required="false"/>
+                    <uses-permission-sdk-23 name="android.permission.ACCESS_NETWORK_STATE"/>
+                    <uses-permission maxSdkVersion="26" name="android.permission.CAMERA"/>
+                    <uses-permission name="android.permission.INTERNET"/>
                 </variant>
             </baseline>
             

--- a/manifestcheck/src/test/kotlin/com/telefonica/manifestcheck/SingleVariantPermissionCheckIntegrationTest.kt
+++ b/manifestcheck/src/test/kotlin/com/telefonica/manifestcheck/SingleVariantPermissionCheckIntegrationTest.kt
@@ -33,11 +33,11 @@ class SingleVariantPermissionCheckIntegrationTest {
             <?xml version="1.0" encoding="UTF-8" standalone="no"?>
             <baseline>
                 <variant name="debug">
-                    <uses-permission name="android.permission.INTERNET"/>
-                    <uses-permission maxSdkVersion="26" name="android.permission.CAMERA"/>
-                    <uses-permission-sdk-23 name="android.permission.ACCESS_NETWORK_STATE"/>
-                    <uses-feature name="android.hardware.camera.autofocus" required="false"/>
                     <uses-feature glEsVersion="0x00020000" required="true"/>
+                    <uses-feature name="android.hardware.camera.autofocus" required="false"/>
+                    <uses-permission-sdk-23 name="android.permission.ACCESS_NETWORK_STATE"/>
+                    <uses-permission maxSdkVersion="26" name="android.permission.CAMERA"/>
+                    <uses-permission name="android.permission.INTERNET"/>
                 </variant>
             </baseline>
 
@@ -72,16 +72,16 @@ class SingleVariantPermissionCheckIntegrationTest {
             <?xml version="1.0" encoding="UTF-8" standalone="no"?>
             <baseline>
                 <variant name="debug">
-                    <uses-permission name="android.permission.INTERNET"/>
-                    <uses-permission maxSdkVersion="26" name="android.permission.CAMERA"/>
-                    <uses-permission-sdk-23 name="android.permission.ACCESS_NETWORK_STATE"/>
-                    <uses-feature name="android.hardware.camera.autofocus" required="false"/>
                     <uses-feature glEsVersion="0x00020000" required="true"/>
+                    <uses-feature name="android.hardware.camera.autofocus" required="false"/>
+                    <uses-permission-sdk-23 name="android.permission.ACCESS_NETWORK_STATE"/>
+                    <uses-permission maxSdkVersion="26" name="android.permission.CAMERA"/>
+                    <uses-permission name="android.permission.INTERNET"/>
                 </variant>
                 <variant name="release">
-                    <uses-permission name="android.permission.INTERNET"/>
-                    <uses-permission maxSdkVersion="26" name="android.permission.CAMERA"/>
                     <uses-permission-sdk-23 name="android.permission.ACCESS_NETWORK_STATE"/>
+                    <uses-permission maxSdkVersion="26" name="android.permission.CAMERA"/>
+                    <uses-permission name="android.permission.INTERNET"/>
                 </variant>
             </baseline>
             
@@ -104,11 +104,11 @@ class SingleVariantPermissionCheckIntegrationTest {
             <?xml version="1.0" encoding="UTF-8" standalone="no"?>
             <baseline>
                 <variant name="debug">
-                    <uses-permission name="android.permission.INTERNET"/>
-                    <uses-permission maxSdkVersion="26" name="android.permission.CAMERA"/>
-                    <uses-permission-sdk-23 name="android.permission.ACCESS_NETWORK_STATE"/>
-                    <uses-feature name="android.hardware.camera.autofocus" required="false"/>
                     <uses-feature glEsVersion="0x00020000" required="true"/>
+                    <uses-feature name="android.hardware.camera.autofocus" required="false"/>
+                    <uses-permission-sdk-23 name="android.permission.ACCESS_NETWORK_STATE"/>
+                    <uses-permission maxSdkVersion="26" name="android.permission.CAMERA"/>
+                    <uses-permission name="android.permission.INTERNET"/>
                 </variant>
             </baseline>
             

--- a/plugin-core/src/main/kotlin/com/telefonica/manifestcheck/internal/BaselineHandler.kt
+++ b/plugin-core/src/main/kotlin/com/telefonica/manifestcheck/internal/BaselineHandler.kt
@@ -34,7 +34,7 @@ internal class BaselineHandler(private val baselineFile: File) {
                 // Create permission entries for a single variant
                 appendElement("variant") {
                     setAttribute("name", variantName)
-                    variantPermissions.forEach { permission ->
+                    variantPermissions.sorted().forEach { permission ->
                         appendChild(permission.toXmlElement(document))
                     }
                 }

--- a/plugin-core/src/test/kotlin/com/telefonica/simonschiller/permissioncheck/internal/BaselineHandlerTest.kt
+++ b/plugin-core/src/test/kotlin/com/telefonica/simonschiller/permissioncheck/internal/BaselineHandlerTest.kt
@@ -321,4 +321,34 @@ class BaselineHandlerTest {
         """.trimIndent()
         assertEquals(expectedBaselineContent, baselineFile.readText().normaliseLineSeparators())
     }
+
+    @Test
+    fun `Baseline serializes permissions in sorted order`() {
+        val baselineFile = tempDir.resolve("permission-baseline.xml")
+        // Intentionally unsorted
+        val permissions = setOf(
+            Permission("android.permission.INTERNET"),
+            Permission("android.permission.CAMERA"),
+            Sdk23Permission("android.permission.CAMERA"),
+            Sdk23Permission("android.permission.ACCESS_FINE_LOCATION")
+        )
+        val baselineHandler = BaselineHandler(baselineFile)
+        baselineHandler.serialize(mapOf("debug" to permissions))
+
+        val expectedBaselineContent = """
+            <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+            <baseline>
+                <variant name="debug">
+                    <uses-permission-sdk-23 name="android.permission.ACCESS_FINE_LOCATION"/>
+                    <uses-permission name="android.permission.CAMERA"/>
+                    <uses-permission-sdk-23 name="android.permission.CAMERA"/>
+                    <uses-permission name="android.permission.INTERNET"/>
+                </variant>
+            </baseline>
+        """.trimIndent()
+        assertEquals(
+            expectedBaselineContent.trim(),
+            baselineFile.readText().normaliseLineSeparators().trim()
+        )
+    }
 }

--- a/sample/app/sample-baseline.xml
+++ b/sample/app/sample-baseline.xml
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <baseline>
     <variant name="debug">
-        <uses-permission name="android.permission.WRITE_EXTERNAL_STORAGE"/>
-        <uses-permission maxSdkVersion="27" name="android.permission.INTERNET"/>
-        <uses-permission name="android.permission.ACCESS_NETWORK_STATE"/>
+        <uses-feature glEsVersion="0x00020000" required="true"/>
+        <uses-feature name="android.hardware.camera.autofocus" required="false"/>
         <uses-permission maxSdkVersion="26" name="android.permission.ACCESS_COARSE_LOCATION"/>
         <uses-permission maxSdkVersion="26" name="android.permission.ACCESS_FINE_LOCATION"/>
+        <uses-permission name="android.permission.ACCESS_NETWORK_STATE"/>
         <uses-permission-sdk-23 name="android.permission.ACCESS_NETWORK_STATE"/>
-        <uses-feature name="android.hardware.camera.autofocus" required="false"/>
-        <uses-feature glEsVersion="0x00020000" required="true"/>
+        <uses-permission maxSdkVersion="27" name="android.permission.INTERNET"/>
+        <uses-permission name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     </variant>
     <variant name="release">
-        <uses-permission name="android.permission.CAMERA"/>
-        <uses-permission maxSdkVersion="27" name="android.permission.INTERNET"/>
-        <uses-permission name="android.permission.ACCESS_NETWORK_STATE"/>
+        <uses-feature glEsVersion="0x00020000" required="true"/>
+        <uses-feature name="android.hardware.camera.autofocus" required="false"/>
         <uses-permission maxSdkVersion="26" name="android.permission.ACCESS_COARSE_LOCATION"/>
         <uses-permission maxSdkVersion="26" name="android.permission.ACCESS_FINE_LOCATION"/>
+        <uses-permission name="android.permission.ACCESS_NETWORK_STATE"/>
         <uses-permission-sdk-23 name="android.permission.ACCESS_NETWORK_STATE"/>
-        <uses-feature name="android.hardware.camera.autofocus" required="false"/>
-        <uses-feature glEsVersion="0x00020000" required="true"/>
+        <uses-permission name="android.permission.CAMERA"/>
+        <uses-permission maxSdkVersion="27" name="android.permission.INTERNET"/>
     </variant>
 </baseline>


### PR DESCRIPTION
Apply permission sorting and not only sort by variant.
Added a new test that checks the ordering which was failing with the current code and that now passes.
Also recreated the sample baseline and updated the permissions ordering in old tests.

The changes are only in the order when recreating the permissions, for checking the order keeps not being important.